### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
         - main
         - develop
 
+permissions:
+  contents: read
+
 jobs:
   biome-ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/KasumiMercury/primind-web/security/code-scanning/2](https://github.com/KasumiMercury/primind-web/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block that grants only the scopes needed for the workflow. Since both jobs only need to read the repository contents (for checkout and scanning), `contents: read` is sufficient. This block can be applied at the workflow root (applies to all jobs) or individually to each job; the minimal and clearest change here is to add a single root-level `permissions` block.

Concretely, in `.github/workflows/ci.yaml`, add a `permissions:` section right after the `on:` block and before `jobs:`. This block should specify `contents: read`. No other permissions appear necessary because there is no code that writes to PRs, issues, or to the repository. No imports or additional definitions are needed since this is just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
